### PR TITLE
chore: release 2025.08.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@
 - feat: support standalone packages
 - feat: add per-package mode
 - feat: allow arg --release-note-path via cli
+- fix: avoid hardcoded "Releases.md" comment
+- fix: avoid error on git checkout cmd
+- fix: git restoration using wrong cmd
+- fix: handle scopeless commits for single packages
+- docs: update ci/codecov urls
+- docs: improve per-package and single package sections
+- refactor: change fork pkg name to @esroyo/deno-bump-workspaces
+- chore: avoid dev files on publish
+- chore: release 2025.08.14 (#1)
+
+### 2025.08.14
+
+#### @esroyo/deno-bump-workspaces 0.2.0 (minor)
+
+- feat: support standalone packages
+- feat: add per-package mode
+- feat: allow arg --release-note-path via cli
 - fix: git restoration using wrong cmd
 - fix: handle scopeless commits for single packages
 - docs: update ci/codecov urls


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@esroyo/deno-bump-workspaces|0.0.0|0.2.0|minor|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Release notes are updated correctly









---

To make edits to this PR:

```sh
git fetch upstream release-2025-08-14-18-02-51 && git checkout -b release-2025-08-14-18-02-51 upstream/release-2025-08-14-18-02-51
```
