### PR TITLE
chore: release 2025.08.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### 2025.08.14
 
+#### @esroyo/deno-bump-workspaces 0.2.1 (patch)
+
+- fix: avoid hardcoded "Releases.md" comment
+- fix: avoid error on git checkout cmd
+- chore: avoid dev files on publish
+
+### 2025.08.14
+
 #### @esroyo/deno-bump-workspaces 0.2.0 (minor)
 
 - feat: support standalone packages


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@esroyo/deno-bump-workspaces|0.2.0|0.2.1|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Release notes are updated correctly









---

To make edits to this PR:

```sh
git fetch upstream release-2025-08-14-18-11-10 && git checkout -b release-2025-08-14-18-11-10 upstream/release-2025-08-14-18-11-10
```
