### PR TITLE
chore: release 2025.08.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### 2025.08.14
 
+#### @esroyo/deno-bump-workspaces 0.2.2 (patch)
+
+- feat: add tagging to the bump/release process
+
+### 2025.08.14
+
 #### @esroyo/deno-bump-workspaces 0.2.1 (patch)
 
 - fix: bumping version on single-packages

--- a/deno.json
+++ b/deno.json
@@ -5,7 +5,7 @@
     ".": "./mod.ts",
     "./cli": "./cli.ts"
   },
-  "version": "0.2.1",
+  "version": "0.2.2",
   "tasks": {
     "test": "deno test -A --parallel",
     "coverage": "deno task test --clean --reporter=dot --coverage=coverage && deno coverage --lcov --output=coverage.lcov --exclude='src/test-utils.ts|vendor' coverage && genhtml -o coverage/report coverage.lcov"


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@esroyo/deno-bump-workspaces|0.2.1|0.2.2|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Release notes are updated correctly









---

To make edits to this PR:

```sh
git fetch upstream release-2025-08-14-20-52-54 && git checkout -b release-2025-08-14-20-52-54 upstream/release-2025-08-14-20-52-54
```
