### PR TITLE
chore: release 2025.08.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### 2025.08.14
 
+#### @esroyo/deno-bump-workspaces 0.2.3 (patch)
+
+- fix: linting errors on cli
+- docs: add info about tagging and merge strategies
+
+### 2025.08.14
+
 #### @esroyo/deno-bump-workspaces 0.2.2 (patch)
 
 - feat: add tagging to the bump/release process

--- a/deno.json
+++ b/deno.json
@@ -5,7 +5,7 @@
     ".": "./mod.ts",
     "./cli": "./cli.ts"
   },
-  "version": "0.2.2",
+  "version": "0.2.3",
   "tasks": {
     "test": "deno test -A --parallel",
     "coverage": "deno task test --clean --reporter=dot --coverage=coverage && deno coverage --lcov --output=coverage.lcov --exclude='src/test-utils.ts|vendor' coverage && genhtml -o coverage/report coverage.lcov"


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@esroyo/deno-bump-workspaces|0.2.2|0.2.3|patch|

Please ensure:
- [x] Versions in deno.json files are updated correctly
- [x] Release notes are updated correctly









---

To make edits to this PR:

```sh
git fetch upstream release-2025-08-14-21-34-10 && git checkout -b release-2025-08-14-21-34-10 upstream/release-2025-08-14-21-34-10
```
